### PR TITLE
FEAT : 운동 기록 조회 API 구현

### DIFF
--- a/src/main/java/com/ureca/fitlog/FitLogApplication.java
+++ b/src/main/java/com/ureca/fitlog/FitLogApplication.java
@@ -5,7 +5,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@MapperScan("com.ureca.fitlog.todos.mapper")
+//@MapperScan("com.ureca.fitlog.todos.mapper")
+@MapperScan(basePackages = "com.ureca.fitlog")  // 10/22 16:30 추가 MyBatis Mapper 경로 전체를 스캔하도록 지정
 public class FitLogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ureca/fitlog/calendar/controller/CalendarController.java
+++ b/src/main/java/com/ureca/fitlog/calendar/controller/CalendarController.java
@@ -1,0 +1,25 @@
+package com.ureca.fitlog.calendar.controller;
+
+import com.ureca.fitlog.calendar.dto.CalendarResponseDTO;
+import com.ureca.fitlog.calendar.service.CalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/calendar")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    /** 달력의 하루 단위 통합 조회 엔드포인트 */
+    @GetMapping
+    public ResponseEntity<CalendarResponseDTO> getDay(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ResponseEntity.ok(calendarService.getDayView(date));
+    }
+}

--- a/src/main/java/com/ureca/fitlog/calendar/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/ureca/fitlog/calendar/dto/CalendarResponseDTO.java
@@ -1,0 +1,50 @@
+package com.ureca.fitlog.calendar.dto;
+
+import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
+import com.ureca.fitlog.todos.dto.TodoResponseDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+public class CalendarResponseDTO {
+
+    public enum Mode { PLAN, RECORD } // 계획/기록
+
+    private LocalDate date;
+    private Mode mode;
+    private double totalCalories;     // RECORD 일 때 의미
+    private List<?> items;            // PLAN: TodoItem[], RECORD: ExerciseItem[]
+    private String message;
+
+    // 기록 뷰
+    public static CalendarResponseDTO record(LocalDate date,
+                                             List<ExerciseResponseDTO.ExerciseItem> items,
+                                             double totalCalories) {
+        CalendarResponseDTO dto = new CalendarResponseDTO();
+        dto.setDate(date);
+        dto.setMode(Mode.RECORD);
+        dto.setItems(items);
+        dto.setTotalCalories(totalCalories);
+        dto.setMessage(items.isEmpty()
+                ? "해당 날짜의 완료된 운동 기록이 없습니다."
+                : "운동 기록이 성공적으로 조회되었습니다.");
+        return dto;
+    }
+
+    // 계획 뷰
+    public static CalendarResponseDTO plan(LocalDate date,
+                                           List<TodoResponseDTO.TodoItem> items) {
+        CalendarResponseDTO dto = new CalendarResponseDTO();
+        dto.setDate(date);
+        dto.setMode(Mode.PLAN);
+        dto.setItems(items);
+        dto.setTotalCalories(0);
+        dto.setMessage(items.isEmpty()
+                ? "해당 날짜의 운동 계획이 없습니다."
+                : "운동 계획이 성공적으로 조회되었습니다.");
+        return dto;
+    }
+}

--- a/src/main/java/com/ureca/fitlog/calendar/service/CalendarService.java
+++ b/src/main/java/com/ureca/fitlog/calendar/service/CalendarService.java
@@ -1,0 +1,41 @@
+package com.ureca.fitlog.calendar.service;
+
+import com.ureca.fitlog.calendar.dto.CalendarResponseDTO;
+import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
+import com.ureca.fitlog.exercise.mapper.ExerciseMapper;
+import com.ureca.fitlog.todos.dto.TodoResponseDTO;
+import com.ureca.fitlog.todos.mapper.TodoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+
+    private final TodoMapper todoMapper;
+    private final ExerciseMapper exerciseMapper;
+
+    public CalendarResponseDTO getDayView(LocalDate date) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        boolean isPast = date.isBefore(today);
+        boolean isToday = date.isEqual(today);
+
+        // ✅ 하루 완료 버튼 기준
+        boolean dayDone = todoMapper.existsTodosDoneTrueByDate(date);
+
+        boolean useRecordView = isPast || (isToday && dayDone);
+
+        if (useRecordView) {
+            List<ExerciseResponseDTO.ExerciseItem> records = exerciseMapper.findCompletedExercisesByDate(date);
+            double totalCalories = exerciseMapper.findTotalCaloriesByDate(date);
+            return CalendarResponseDTO.record(date, records, totalCalories);
+        } else {
+            List<TodoResponseDTO.TodoItem> plans = todoMapper.findTodosByDate(date);
+            return CalendarResponseDTO.plan(date, plans);
+        }
+    }
+}

--- a/src/main/java/com/ureca/fitlog/exercise/controller/ExerciseController.java
+++ b/src/main/java/com/ureca/fitlog/exercise/controller/ExerciseController.java
@@ -1,0 +1,25 @@
+package com.ureca.fitlog.exercise.controller;
+
+import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
+import com.ureca.fitlog.exercise.service.ExerciseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/exercises")
+public class ExerciseController {
+
+    private final ExerciseService exerciseService;
+
+    /** 특정 날짜 완료 기록 조회(단독 호출용) */
+    @GetMapping
+    public ResponseEntity<ExerciseResponseDTO> getCompletedByDate(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ResponseEntity.ok(exerciseService.getCompletedRecords(date));
+    }
+}

--- a/src/main/java/com/ureca/fitlog/exercise/dto/ExerciseResponseDTO.java
+++ b/src/main/java/com/ureca/fitlog/exercise/dto/ExerciseResponseDTO.java
@@ -1,0 +1,28 @@
+package com.ureca.fitlog.exercise.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+public class ExerciseResponseDTO {
+    private LocalDate date;                           // 조회 날짜
+    private List<ExerciseItem> exercises;             // 완료된 운동 목록
+    private double totalCalories;                     // 해당 날짜 총 소모 칼로리
+    private String message;
+
+    @Getter @Setter
+    public static class ExerciseItem {
+        private Long todoId;                          // 투두 ID (참조용)
+        private Long exerciseId;                      // 운동 ID
+        private String exerciseName;                  // 운동 이름
+        private Integer setsNumber;                   // 세트 수
+        private Integer repsTarget;                   // 세트당 횟수/시간
+        private Integer restTime;                     // 휴식(초)
+        private Boolean isCompleted;                  // 완료 여부
+        private Double caloriesPerRep;                // 1회(혹은 1단위)당 칼로리
+        private Double totalCalories;                 // 해당 항목 총 칼로리 = sets*reps*cal/rep
+    }
+}

--- a/src/main/java/com/ureca/fitlog/exercise/mapper/ExerciseMapper.java
+++ b/src/main/java/com/ureca/fitlog/exercise/mapper/ExerciseMapper.java
@@ -1,0 +1,18 @@
+package com.ureca.fitlog.exercise.mapper;
+
+import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface ExerciseMapper {
+
+    /** 특정 날짜의 '완료된' 운동 항목 목록 (칼로리 포함) */
+    List<ExerciseResponseDTO.ExerciseItem> findCompletedExercisesByDate(@Param("date") LocalDate date);
+
+    /** 특정 날짜의 총 소모 칼로리 */
+    double findTotalCaloriesByDate(@Param("date") LocalDate date);
+}

--- a/src/main/java/com/ureca/fitlog/exercise/service/ExerciseService.java
+++ b/src/main/java/com/ureca/fitlog/exercise/service/ExerciseService.java
@@ -1,0 +1,31 @@
+package com.ureca.fitlog.exercise.service;
+
+import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
+import com.ureca.fitlog.exercise.mapper.ExerciseMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseService {
+
+    private final ExerciseMapper exerciseMapper;
+
+    /** 기록(완료) 뷰: 완료 항목 + 총 칼로리 */
+    public ExerciseResponseDTO getCompletedRecords(LocalDate date) {
+        List<ExerciseResponseDTO.ExerciseItem> records = exerciseMapper.findCompletedExercisesByDate(date);
+        double totalCalories = exerciseMapper.findTotalCaloriesByDate(date);
+
+        ExerciseResponseDTO dto = new ExerciseResponseDTO();
+        dto.setDate(date);
+        dto.setExercises(records);
+        dto.setTotalCalories(totalCalories);
+        dto.setMessage(records.isEmpty()
+                ? "해당 날짜에 완료된 운동 기록이 없습니다."
+                : "운동 기록이 성공적으로 조회되었습니다.");
+        return dto;
+    }
+}

--- a/src/main/java/com/ureca/fitlog/todos/dto/TodoRequestDTO.java
+++ b/src/main/java/com/ureca/fitlog/todos/dto/TodoRequestDTO.java
@@ -14,5 +14,7 @@ public class TodoRequestDTO {
     private Integer setsNumber;   // 세트 수
     private Integer repsTarget;   // 세트당 목표 횟수 (유산소일 경우 시간)
     private Integer restTime;     // 총 휴식시간 (초 단위)
+    private Boolean isCompleted;  // 개별 세트 완료 여부 - 10/22 17:06 수정
+    private Boolean isDone;       // 하루 전체 완료 여부 (운동 완료 버튼) - 10/22 17:06 수정
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/ureca/fitlog/todos/dto/TodoResponseDTO.java
+++ b/src/main/java/com/ureca/fitlog/todos/dto/TodoResponseDTO.java
@@ -3,26 +3,25 @@ package com.ureca.fitlog.todos.dto;
 import lombok.Getter;
 import lombok.Setter;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Setter
 public class TodoResponseDTO {
     private LocalDate date;          // 날짜
-    private List<TodoItem> todos;    // 투두 목록
-    private String message;          // 응답 메시지
+    private List<TodoItem> todos;    // 투두 리스트
+    private String message;
 
     @Getter
     @Setter
     public static class TodoItem {
-        private Long todoId;         // 투두 ID
-        private Long exerciseId;     // 운동 ID
-        private String exerciseName; // 운동 이름
-        private Integer setsNumber;  // 세트 수
-        private Integer repsTarget;  // 세트당 목표 횟수 (또는 유산소 시간)
-        private Integer restTime;    // 총 휴식시간
-        private Boolean isCompleted; // 완료 여부
-        private LocalDateTime createdAt;
+        private Long todoId;
+        private Long exerciseId;
+        private String exerciseName;
+        private Integer setsNumber;
+        private Integer repsTarget;
+        private Integer restTime;
+        private Boolean isCompleted;  // 세트별 완료 여부
+        private Boolean isDone;       // ✅ 하루 전체 완료 여부
     }
 }

--- a/src/main/java/com/ureca/fitlog/todos/mapper/TodoMapper.java
+++ b/src/main/java/com/ureca/fitlog/todos/mapper/TodoMapper.java
@@ -1,20 +1,27 @@
 package com.ureca.fitlog.todos.mapper;
 
 import com.ureca.fitlog.todos.dto.TodoRequestDTO;
+import com.ureca.fitlog.todos.dto.TodoResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
 public interface TodoMapper {
-    void insertTodo(TodoRequestDTO dto);
-    List<com.ureca.fitlog.todos.dto.TodoResponseDTO.TodoItem> findTodosByDate(@Param("date") LocalDate date);
-    int updateTodoCompletion(@Param("todoId") Long todoId, @Param("isCompleted") Boolean isCompleted);
-    int updateTodo(com.ureca.fitlog.todos.dto.TodoRequestDTO dto);
-    int deleteTodoById(@Param("todoId") Long todoId);
-    LocalDateTime findCreatedAtById(Long todoId);
-}
 
+    void insertTodo(TodoRequestDTO dto);
+    List<TodoResponseDTO.TodoItem> findTodosByDate(@Param("date") LocalDate date);
+    int updateTodoCompletion(@Param("todoId") Long todoId, @Param("isCompleted") Boolean isCompleted);
+    int updateTodo(TodoRequestDTO dto);
+    int deleteTodoById(@Param("todoId") Long todoId);
+
+    // ✅ is_done 관련 추가
+    int updateTodosDoneStatus(@Param("date") LocalDate date, @Param("isDone") Boolean isDone);
+    boolean existsTodosDoneTrueByDate(@Param("date") LocalDate date);
+
+    // 참고용
+    int countTodosByDate(@Param("date") LocalDate date);
+    int countTodosByDateAndNotCompleted(@Param("date") LocalDate date);
+}

--- a/src/main/java/com/ureca/fitlog/todos/service/TodoService.java
+++ b/src/main/java/com/ureca/fitlog/todos/service/TodoService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,12 +20,11 @@ public class TodoService {
     /** 투두 생성 */
     public Map<String, Object> createTodo(TodoRequestDTO dto) {
         todoMapper.insertTodo(dto);
-        LocalDateTime createdAt = todoMapper.findCreatedAtById(dto.getTodoId());
         Map<String, Object> response = new HashMap<>();
         response.put("date", dto.getDate());
         response.put("todoId", dto.getTodoId());
-        response.put("createdAt", createdAt);
         response.put("isCompleted", false);
+        response.put("isDone", false); // ✅ 하루 완료 상태 초기값
         response.put("message", "TodoList가 성공적으로 생성되었습니다.");
         return response;
     }
@@ -42,6 +40,7 @@ public class TodoService {
                 : "TodoList가 성공적으로 조회되었습니다.");
         return response;
     }
+
     /** 투두 완료 체크 */
     public Map<String, Object> updateTodoCompletion(Long todoId, Boolean isCompleted) {
         int updated = todoMapper.updateTodoCompletion(todoId, isCompleted);
@@ -55,6 +54,7 @@ public class TodoService {
         }
         return response;
     }
+
     /** 투두 수정 */
     public Map<String, Object> updateTodo(TodoRequestDTO dto) {
         int updated = todoMapper.updateTodo(dto);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/fitlog
     username: root
-    password: urecaureca
+    password: ureca
 
 springdoc:
   api-docs:
@@ -16,9 +16,11 @@ springdoc:
   default-produces-media-type: application/json
   default-consumes-media-type: application/json
 
+# mybatis
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml
-  type-aliases-package: com.ureca.fitlog.dto
+  #type-aliases-package: com.ureca.fitlog.domain 아래의 행은 10/22 16:34에 수정함
+  type-aliases-package: com.ureca.fitlog.todos.dto, com.ureca.fitlog.exercise.dto, com.ureca.fitlog.calendar.dto
 
 logging:
   level:

--- a/src/main/resources/mapper/ExerciseMapper.xml
+++ b/src/main/resources/mapper/ExerciseMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ureca.fitlog.exercise.mapper.ExerciseMapper">
+
+    <!-- 완료된 운동 목록 + 항목별 칼로리 -->
+    <select id="findCompletedExercisesByDate"
+            parameterType="java.time.LocalDate"
+            resultType="com.ureca.fitlog.exercise.dto.ExerciseResponseDTO$ExerciseItem">
+        SELECT
+            t.todo_id AS todoId,
+            t.exercise_id AS exerciseId,
+            e.name AS exerciseName,
+            t.sets_number AS setsNumber,
+            t.reps_target AS repsTarget,
+            t.rest_time AS restTime,
+            t.is_completed AS isCompleted,
+            e.default_calories_per_set AS caloriesPerRep,
+            (t.sets_number * t.reps_target * e.default_calories_per_set) AS totalCalories
+        FROM todos t
+                 JOIN exercises e ON t.exercise_id = e.exercise_id
+        WHERE t.date = #{date}
+          AND t.is_completed = TRUE
+        ORDER BY t.todo_id ASC
+    </select>
+
+    <!-- 해당 날짜 총 소모 칼로리 -->
+    <select id="findTotalCaloriesByDate"
+            parameterType="java.time.LocalDate"
+            resultType="double">
+        SELECT IFNULL(SUM(t.sets_number * t.reps_target * e.default_calories_per_set), 0)
+        FROM todos t
+                 JOIN exercises e ON t.exercise_id = e.exercise_id
+        WHERE t.date = #{date}
+          AND t.is_completed = TRUE
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -5,22 +5,24 @@
 
 <mapper namespace="com.ureca.fitlog.todos.mapper.TodoMapper">
 
-    <!-- todo 생성 -->
+    <!-- 투두 생성 -->
     <insert id="insertTodo"
             parameterType="com.ureca.fitlog.todos.dto.TodoRequestDTO"
             useGeneratedKeys="true"
             keyProperty="todoId">
         INSERT INTO todos (
-        user_id, exercise_id, date, sets_number, reps_target, rest_time
+            user_id, exercise_id, date, sets_number, reps_target, rest_time, is_completed, is_done
         )
         VALUES (
-        1,                       <!-- 임시 유저 ID -->
-        #{exerciseId},
-        #{date},
-        #{setsNumber},
-        #{repsTarget},
-        #{restTime}
-        );
+                   1,
+                   #{exerciseId},
+                   #{date},
+                   #{setsNumber},
+                   #{repsTarget},
+                   #{restTime},
+                   #{isCompleted},
+                   #{isDone}
+               );
     </insert>
 
     <!-- 날짜별 투두 조회 -->
@@ -35,24 +37,21 @@
             t.reps_target AS repsTarget,
             t.rest_time AS restTime,
             t.is_completed AS isCompleted,
-            t.created_at AS createdAt
+            t.is_done AS isDone
         FROM todos t
                  JOIN exercises e ON t.exercise_id = e.exercise_id
         WHERE t.date = #{date}
         ORDER BY t.todo_id ASC;
     </select>
-    <select id="findCreatedAtById" resultType="java.time.LocalDateTime">
-        SELECT created_at FROM todos WHERE todo_id = #{todoId};
-    </select>
 
-    <!-- 완료 상태 업데이트 -->
+    <!-- 완료 체크 -->
     <update id="updateTodoCompletion">
         UPDATE todos
         SET is_completed = #{isCompleted}
         WHERE todo_id = #{todoId};
     </update>
 
-    <!-- 투두 수정 -->
+    <!-- 수정 -->
     <update id="updateTodo"
             parameterType="com.ureca.fitlog.todos.dto.TodoRequestDTO">
         UPDATE todos
@@ -62,14 +61,41 @@
             sets_number = #{setsNumber},
             reps_target = #{repsTarget},
             rest_time = #{restTime},
+            is_completed = #{isCompleted},
             updated_at = CURRENT_TIMESTAMP
         WHERE todo_id = #{todoId};
     </update>
 
     <!-- 삭제 -->
     <delete id="deleteTodoById">
-        DELETE FROM todos
-        WHERE todo_id = #{todoId};
+        DELETE FROM todos WHERE todo_id = #{todoId};
     </delete>
 
+    <!-- ✅ 하루 완료 버튼(is_done) 업데이트 -->
+    <update id="updateTodosDoneStatus">
+        UPDATE todos
+        SET is_done = #{isDone}
+        WHERE date = #{date};
+    </update>
+
+    <!-- ✅ 하루 완료 여부 확인 -->
+    <select id="existsTodosDoneTrueByDate"
+            parameterType="java.time.LocalDate"
+            resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM todos
+        WHERE date = #{date}
+          AND is_done = TRUE;
+    </select>
+
+    <!-- 참고용 통계 -->
+    <select id="countTodosByDate" parameterType="java.time.LocalDate" resultType="int">
+        SELECT COUNT(*) FROM todos WHERE date = #{date}
+    </select>
+
+    <select id="countTodosByDateAndNotCompleted" parameterType="java.time.LocalDate" resultType="int">
+        SELECT COUNT(*) FROM todos
+        WHERE date = #{date}
+          AND (is_completed IS NULL OR is_completed = FALSE)
+    </select>
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3

## 📝작업 내용

> 운동 기록 조회 API를 구현
> 달력에서 날짜를 눌렀을 때, ToDo를 조회하는 기능에 이어서 완료한 운동 기록을 조회하는 기능 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
