### PR TITLE
FEAT: 운동 목록 조회 API 구현#17

### DIFF
--- a/src/main/java/com/ureca/fitlog/exercise/controller/ExerciseController.java
+++ b/src/main/java/com/ureca/fitlog/exercise/controller/ExerciseController.java
@@ -1,5 +1,6 @@
 package com.ureca.fitlog.exercise.controller;
 
+import com.ureca.fitlog.exercise.dto.ExerciseListResponseDTO;
 import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
 import com.ureca.fitlog.exercise.service.ExerciseService;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,5 +24,14 @@ public class ExerciseController {
     public ResponseEntity<ExerciseResponseDTO> getCompletedByDate(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         return ResponseEntity.ok(exerciseService.getCompletedRecords(date));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Map<String, Object>> searchExercises(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(exerciseService.getExercises(keyword, page, size));
     }
 }

--- a/src/main/java/com/ureca/fitlog/exercise/dto/ExerciseListResponseDTO.java
+++ b/src/main/java/com/ureca/fitlog/exercise/dto/ExerciseListResponseDTO.java
@@ -1,0 +1,17 @@
+package com.ureca.fitlog.exercise.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExerciseListResponseDTO {
+    private Long exerciseId;              // 운동 ID
+    private String name;                  // 운동명
+    private Double defaultCaloriesPerSet; // 1회(또는 1분) 기준 칼로리
+//    private String unit;                  // 단위 (회 / 분)
+}

--- a/src/main/java/com/ureca/fitlog/exercise/mapper/ExerciseMapper.java
+++ b/src/main/java/com/ureca/fitlog/exercise/mapper/ExerciseMapper.java
@@ -1,5 +1,6 @@
 package com.ureca.fitlog.exercise.mapper;
 
+import com.ureca.fitlog.exercise.dto.ExerciseListResponseDTO;
 import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -15,4 +16,12 @@ public interface ExerciseMapper {
 
     /** 특정 날짜의 총 소모 칼로리 */
     double findTotalCaloriesByDate(@Param("date") LocalDate date);
+
+    List<ExerciseListResponseDTO> findExercises(
+            @Param("keyword") String keyword,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    int countExercises(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/ureca/fitlog/exercise/service/ExerciseService.java
+++ b/src/main/java/com/ureca/fitlog/exercise/service/ExerciseService.java
@@ -1,12 +1,15 @@
 package com.ureca.fitlog.exercise.service;
 
+import com.ureca.fitlog.exercise.dto.ExerciseListResponseDTO;
 import com.ureca.fitlog.exercise.dto.ExerciseResponseDTO;
 import com.ureca.fitlog.exercise.mapper.ExerciseMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -27,5 +30,21 @@ public class ExerciseService {
                 ? "해당 날짜에 완료된 운동 기록이 없습니다."
                 : "운동 기록이 성공적으로 조회되었습니다.");
         return dto;
+    }
+    /** 운동목록 list */
+    public Map<String, Object> getExercises(String keyword, int page, int size) {
+        int offset = page * size;
+
+        List<ExerciseListResponseDTO> exercises = exerciseMapper.findExercises(keyword, offset, size);
+        int totalCount = exerciseMapper.countExercises(keyword);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("page", page);
+        result.put("size", size);
+        result.put("totalCount", totalCount);
+        result.put("totalPages", (int) Math.ceil((double) totalCount / size));
+        result.put("exercises", exercises);
+
+        return result;
     }
 }

--- a/src/main/resources/mapper/ExerciseMapper.xml
+++ b/src/main/resources/mapper/ExerciseMapper.xml
@@ -36,4 +36,35 @@
           AND t.is_completed = TRUE
     </select>
 
+    <!-- 운동 종목 전체 조회/검색 (드롭다운/리스트용) -->
+    <select id="findExercises"
+            resultType="com.ureca.fitlog.exercise.dto.ExerciseListResponseDTO">
+        SELECT
+        exercise_id AS exerciseId,
+        name,
+        default_calories_per_set AS defaultCaloriesPerSet,
+        unit
+        FROM exercises
+        <where>
+            <if test="keyword != null and keyword != ''">
+                name LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+        </where>
+        ORDER BY name ASC
+        LIMIT #{limit} OFFSET #{offset};
+    </select>
+
+    <!-- 전체 개수 조회 -->
+    <select id="countExercises" resultType="int">
+        SELECT COUNT(*)
+        FROM exercises
+        <where>
+            <if test="keyword != null and keyword != ''">
+                name LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+        </where>
+    </select>
+
+
+
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #17 

## 📝작업 내용

> 운동 목록을 조회하는 API를 구현하였습니다.
>  - **/exercises/search**
>      - parameter
>           - keyword, page (0부터 시작), size

### 스크린샷 (선택)
<img width="1129" height="934" alt="image" src="https://github.com/user-attachments/assets/e6a13ab9-2629-4cb3-8625-aae107a434c0" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
