### PR TITLE
FIX: 운동 항목 삭제 시 세트 번호 꼬이는 오류 수정 (#46)

### DIFF
--- a/src/main/java/com/ureca/fitlog/todos/mapper/TodoMapper.java
+++ b/src/main/java/com/ureca/fitlog/todos/mapper/TodoMapper.java
@@ -34,6 +34,8 @@ public interface TodoMapper {
     Boolean getIsCompletedById(@Param("todoId") Long todoId,
                                       @Param("userId") Long userId);
 
+    Map<String, Object> findBaseInfoByTodoId(Long todoId, Long userId);
+
     /** [UPDATE] 세트의 완료 상태 토글 (userId 검증 포함) */
     int updateTodoCompletion(@Param("todoId") Long todoId,
                              @Param("userId") Long userId,
@@ -68,25 +70,15 @@ public interface TodoMapper {
     int deleteTodoById(@Param("todoId") Long todoId,
                        @Param("userId") Long userId);
 
-    /** 삭제된 todo의 date, exercise_id 조회 (userId 검증 포함) */
-    Map<String, Object> findDateAndExerciseIdByTodoId(@Param("todoId") Long todoId,
-                                                      @Param("userId") Long userId);
-
     /** [DELETE] work_id 기준으로 해당 운동 목록 삭제 */
     void deleteByWorkoutId(
             @Param("workoutId") Long workoutId,
             @Param("userId") Long userId
     );
 
-    /** 특정 날짜 + 운동종목(exercise_id)의 sets_number 임시 음수화 (userId 필터링) */
-    void tempNegateSetsNumbers(@Param("date") LocalDate date,
-                               @Param("exerciseId") Long exerciseId,
-                               @Param("userId") Long userId);
+    Map<String, Object> findWorkoutIdAndSetNumberByTodoId(Long todoId, Long userId);
 
-    /** 특정 날짜 + 운동종목(exercise_id)의 sets_number 재정렬 (userId 필터링) */
-    void reorderSetsNumbers(@Param("date") LocalDate date,
-                            @Param("exerciseId") Long exerciseId,
-                            @Param("userId") Long userId);
+    void reorderSetsByWorkoutId(Long workoutId, Long userId);
 
     /** 세트별 휴식시간 기록 */
     int updateRestTime(@Param("todoId") Long todoId,

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -39,7 +39,12 @@
                  )
     </insert>
 
-
+    <select id="findBaseInfoByTodoId" resultType="map">
+        SELECT date, exercise_id
+        FROM todos
+        WHERE todo_id = #{todoId}
+          AND user_id = #{userId}
+    </select>
 
     <select id="findMaxSetsNumberByTodoId" resultType="int">
         SELECT MAX(sets_number)
@@ -129,35 +134,6 @@
           AND user_id = #{userId};
     </update>
 
-
-    <!-- 세트번호 임시 음수화 (userId 필터링) -->
-    <update id="tempNegateSetsNumbers" parameterType="map">
-        UPDATE todos
-        SET sets_number = -(sets_number)
-        WHERE date = #{date}
-          AND exercise_id = #{exerciseId}
-          AND user_id = #{userId};
-    </update>
-
-    <!-- 세트번호 재정렬 (userId 필터링) -->
-    <update id="reorderSetsNumbers" parameterType="map">
-        UPDATE todos t
-            JOIN (
-            SELECT
-            todo_id,
-            ROW_NUMBER() OVER (ORDER BY todo_id ASC) AS new_number
-            FROM todos
-            WHERE date = #{date}
-            AND exercise_id = #{exerciseId}
-            AND user_id = #{userId}
-            ) ranked
-        ON t.todo_id = ranked.todo_id
-            SET t.sets_number = ranked.new_number
-        WHERE t.date = #{date}
-          AND t.exercise_id = #{exerciseId}
-          AND t.user_id = #{userId};
-    </update>
-
     <!-- 특정 todo_id 삭제 (userId 검증 포함) -->
     <delete id="deleteTodoById" parameterType="map">
         DELETE FROM todos
@@ -172,13 +148,28 @@
           AND user_id = #{userId}
     </delete>
 
-    <!-- 삭제된 todo의 date, exercise_id 조회 (userId 검증 포함) -->
-    <select id="findDateAndExerciseIdByTodoId" parameterType="map" resultType="map">
-        SELECT date, exercise_id
+    <!-- 삭제 대상 조회 (workout_id + sets_number) -->
+    <select id="findWorkoutIdAndSetNumberByTodoId" resultType="map">
+        SELECT workout_id, sets_number
         FROM todos
         WHERE todo_id = #{todoId}
-          AND user_id = #{userId};
+          AND user_id = #{userId}
     </select>
+
+    <!-- workout_id 기준 재정렬 (ROW_NUMBER 방식) -->
+    <update id="reorderSetsByWorkoutId">
+        UPDATE todos t
+            JOIN (
+            SELECT
+            todo_id,
+            ROW_NUMBER() OVER (ORDER BY sets_number ASC, todo_id ASC) AS new_number
+            FROM todos
+            WHERE workout_id = #{workoutId}
+            AND user_id = #{userId}
+            ) r ON t.todo_id = r.todo_id
+            SET t.sets_number = r.new_number
+        WHERE t.user_id = #{userId}
+    </update>
 
     <!-- 하루 완료 버튼(is_done) 업데이트 (userId 필터링) -->
     <update id="updateTodosDoneStatus">


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #46

## 📝작업 내용

> 운동 항목 전체 삭제 시 정상적으로 작동하지 않는 부분을 수정했습니다.
> 남은 기능(세트 추가/삭제 시 조회하는 mapper로직)들도 workout_id 기반 동작으로 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
